### PR TITLE
Update CircleCI and support JVM flags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+# Python CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-python/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # This was the easiest way to get Python, the JRE and Maven in one image
+      - image: openkbs/jre-mvn-py3
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "pom.xml" }}
+
+      - run:
+          name: install dependencies
+          # We need to install venv as the image doesn't provide it
+          command: |
+            apt-get -q update
+            apt-get -qy install python3-venv
+            python3 -m venv venv
+            . venv/bin/activate
+            pip install --upgrade pip
+            pip install -r requirements.txt
+            mvn -q dependency:copy-dependencies -DoutputDirectory=./jars
+
+      - save_cache:
+          paths:
+            - ./venv
+            - ./jars
+          key: v1-dependencies-{{ checksum "requirements.txt" }}-{{ checksum "pom.xml" }}
+
+      - run:
+          name: run tests
+          command: |
+            . venv/bin/activate
+            python setup.py install
+            ./test.sh
+
+      - store_artifacts:
+          path: test-reports
+          destination: test-reports

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Other examples can be found in the [test](https://github.com/FraBle/python-sutim
 
 #### Functions
 ```python
-SUTime(jars=[], jvm_started=False, mark_time_ranges=False, include_range=False)
+SUTime(jars=None, jvm_started=False, mark_time_ranges=False, include_range=False, jvm_flags=None)
     """
     jars: List of paths to the SUTime Java dependencies.
     jvm_started: Optional attribute to specify if the JVM has already been
@@ -72,6 +72,10 @@ SUTime(jars=[], jvm_started=False, mark_time_ranges=False, include_range=False)
         sutime.includeRange. Default is False.
         "Tells sutime to mark phrases such as 'From January to March'
         instead of marking 'January' and 'March' separately"
+    jvm_flags: Optional attribute to specify an iterable of string flags
+        to be provided to the JVM at startup. For example, this may be
+        used to specify the maximum heap size using '-Xmx'. Has no effect
+        if jvm_started is set to False. Default is an empty tuple.
     """
 
 sutime.parse(input_str, reference_date=''):

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ SUTime(jars=None, jvm_started=False, mark_time_ranges=False, include_range=False
     jvm_flags: Optional attribute to specify an iterable of string flags
         to be provided to the JVM at startup. For example, this may be
         used to specify the maximum heap size using '-Xmx'. Has no effect
-        if jvm_started is set to False. Default is an empty tuple.
+        if jvm_started is set to True. Default is None.
     """
 
 sutime.parse(input_str, reference_date=''):

--- a/circle.yml
+++ b/circle.yml
@@ -1,8 +1,0 @@
-test:
-    override:
-        - py.test
-
-dependencies: 
-  pre:
-    - pip install pytest pytest-cov python-dateutil aniso8601
-    - mvn dependency:copy-dependencies -DoutputDirectory=./jars

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytest
+pytest-cov
+python-dateutil
+aniso8601
+JPype1

--- a/sutime/sutime.py
+++ b/sutime/sutime.py
@@ -24,6 +24,10 @@ class SUTime(object):
             sutime.includeRange. Default is False.
             "Tells sutime to mark phrases such as 'From January to March'
             instead of marking 'January' and 'March' separately"
+        jvm_flags: Optional attribute to specify an iterable of string flags
+            to be provided to the JVM at startup. For example, this may be
+            used to specify the maximum heap size using '-Xmx'. Has no effect
+            if jvm_started is set to False. Default is None.
     """
 
     _required_jars = {
@@ -33,18 +37,19 @@ class SUTime(object):
         'slf4j-simple-1.7.21.jar'
     }
 
-    def __init__(self, jars=[], jvm_started=False, mark_time_ranges=False, include_range=False):
+    def __init__(self, jars=None, jvm_started=False, mark_time_ranges=False, include_range=False,
+                 jvm_flags=None):
         """Initializes SUTime.
         """
         self.mark_time_ranges = mark_time_ranges
         self.include_range = include_range
-        self.jars = jars
+        self.jars = jars if jars is not None else []
         self._is_loaded = False
         self._lock = threading.Lock()
 
         if not jvm_started:
             self._classpath = self._create_classpath()
-            self._start_jvm()
+            self._start_jvm(jvm_flags)
 
         try:
             # make it thread-safe
@@ -61,12 +66,14 @@ class SUTime(object):
         finally:
             self._lock.release()
 
-    def _start_jvm(self):
+    def _start_jvm(self, additional_flags):
         if jpype.isJVMStarted() is not 1:
+            flags = ['-Djava.class.path=' + self._classpath,]
+            if additional_flags:
+                flags.extend(additional_flags)
             jpype.startJVM(
                 jpype.getDefaultJVMPath(),
-                '-Djava.class.path={classpath}'.format(
-                    classpath=self._classpath)
+                *flags
             )
 
     def _create_classpath(self):

--- a/sutime/sutime.py
+++ b/sutime/sutime.py
@@ -27,7 +27,7 @@ class SUTime(object):
         jvm_flags: Optional attribute to specify an iterable of string flags
             to be provided to the JVM at startup. For example, this may be
             used to specify the maximum heap size using '-Xmx'. Has no effect
-            if jvm_started is set to False. Default is None.
+            if jvm_started is set to True. Default is None.
     """
 
     _required_jars = {

--- a/sutime/test/conftest.py
+++ b/sutime/test/conftest.py
@@ -1,0 +1,48 @@
+from datetime import date, time, timedelta
+
+import pytest
+
+
+@pytest.fixture
+def input_duration_range():
+    return 'I need a desk for tomorrow from 2pm to 3pm'
+
+
+@pytest.fixture
+def input_christmas_eve():
+    return 'christmas eve'
+
+
+@pytest.fixture
+def input_sunday_night():
+    return 'Mary had spent Sunday night with us.'
+
+
+@pytest.fixture
+def input_duration():
+    return 'I need a desk for tomorrow from 2pm for 2 hours'
+
+
+@pytest.fixture
+def input_today():
+    return 'I have written a test today.'
+
+
+@pytest.fixture(scope='module')
+def tomorrow():
+    return date.today() + timedelta(days=1)
+
+
+@pytest.fixture(scope='module')
+def two_pm():
+    return time(hour=14)
+
+
+@pytest.fixture(scope='module')
+def three_pm():
+    return time(hour=15)
+
+
+@pytest.fixture(scope='module')
+def reference_date():
+    return date(2017, 1, 9)

--- a/sutime/test/test_sutime.py
+++ b/sutime/test/test_sutime.py
@@ -1,64 +1,16 @@
 import os
-import pytest
+from datetime import timedelta
+
 import aniso8601
-from datetime import date, time, timedelta
+import pytest
 from dateutil import parser
+
 from sutime import SUTime
 
 
 @pytest.fixture(scope='module')
 def sutime():
     return SUTime(jars=os.path.join(*[os.path.dirname(__file__), os.pardir, os.pardir, 'jars']))
-
-
-@pytest.fixture(scope='module')
-def sutime_with_mark_time_ranges():
-    return SUTime(jars=os.path.join(*[os.path.dirname(__file__), os.pardir, os.pardir, 'jars']), mark_time_ranges=True)
-
-
-@pytest.fixture
-def input_duration():
-    return 'I need a desk for tomorrow from 2pm for 2 hours'
-
-
-@pytest.fixture
-def input_duration_range():
-    return 'I need a desk for tomorrow from 2pm to 3pm'
-
-
-@pytest.fixture
-def input_christmas_eve():
-    return 'christmas eve'
-
-
-@pytest.fixture
-def input_sunday_night():
-    return 'Mary had spent Sunday night with us.'
-
-
-@pytest.fixture
-def input_today():
-    return 'I have written a test today.'
-
-
-@pytest.fixture(scope='module')
-def tomorrow():
-    return date.today() + timedelta(days=1)
-
-
-@pytest.fixture(scope='module')
-def two_pm():
-    return time(hour=14)
-
-
-@pytest.fixture(scope='module')
-def three_pm():
-    return time(hour=15)
-
-
-@pytest.fixture(scope='module')
-def reference_date():
-    return date(2017, 1, 9)
 
 
 def test_parse_duration(sutime, input_duration, tomorrow, two_pm):
@@ -89,37 +41,6 @@ def test_parse_duration_range(sutime, input_duration_range, tomorrow, two_pm, th
 
     assert result[2][u'type'] == u'TIME'
     assert parser.parse(result[2][u'value']).time() == three_pm
-
-
-def test_parse_duration_range_with_mark_time_ranges(sutime_with_mark_time_ranges, input_duration_range, tomorrow, two_pm, three_pm):
-    result = sutime_with_mark_time_ranges.parse(input_duration_range)
-
-    assert len(result) == 2
-
-    assert result[0][u'type'] == u'DATE'
-    assert parser.parse(result[0][u'value']).date() == tomorrow
-
-    assert result[1][u'type'] == u'DURATION'
-
-    begin = result[1][u'value'][u'begin']
-    assert parser.parse(begin).time() == two_pm
-
-    end = result[1][u'value'][u'end']
-    assert parser.parse(end).time() == three_pm
-
-
-def test_parse_christmas(sutime_with_mark_time_ranges, input_christmas_eve):
-    result = sutime_with_mark_time_ranges.parse(input_christmas_eve)
-
-    assert len(result) == 1
-
-    assert result[0][u'type'] == u'SET'
-    assert result[0][u'value'] == u'XXXX-12-24'
-
-
-def test_sunday_night(sutime_with_mark_time_ranges, input_sunday_night):
-    result = sutime_with_mark_time_ranges.parse(input_sunday_night)
-    assert len(result) == 1
 
 
 def test_reference_date(sutime, input_today, reference_date):

--- a/sutime/test/test_sutime_jvm_flags.py
+++ b/sutime/test/test_sutime_jvm_flags.py
@@ -1,0 +1,18 @@
+import os
+
+import pytest
+
+from sutime import SUTime
+
+
+@pytest.fixture(scope='module')
+def sutime_with_jvm_flags():
+    return SUTime(jars=os.path.join(*[os.path.dirname(__file__), os.pardir, os.pardir, 'jars']),
+                  jvm_flags=('-Xms256m',))
+
+
+def test_jvm_flags(sutime_with_jvm_flags, input_today, reference_date):
+    # We can't test the effect of the JVM flags, all we can do is test
+    # that basic functionality is ok
+    result = sutime_with_jvm_flags.parse(input_today, reference_date.isoformat())
+    assert len(result) == 1

--- a/sutime/test/test_sutime_time_ranges.py
+++ b/sutime/test/test_sutime_time_ranges.py
@@ -1,0 +1,42 @@
+import os
+import pytest
+from dateutil import parser
+from sutime import SUTime
+
+
+@pytest.fixture(scope='module')
+def sutime_with_mark_time_ranges():
+    return SUTime(jars=os.path.join(*[os.path.dirname(__file__), os.pardir, os.pardir, 'jars']),
+                  mark_time_ranges=True)
+
+
+def test_parse_duration_range_with_mark_time_ranges(
+        sutime_with_mark_time_ranges, input_duration_range, tomorrow, two_pm, three_pm):
+    result = sutime_with_mark_time_ranges.parse(input_duration_range)
+
+    assert len(result) == 2
+
+    assert result[0][u'type'] == u'DATE'
+    assert parser.parse(result[0][u'value']).date() == tomorrow
+
+    assert result[1][u'type'] == u'DURATION'
+
+    begin = result[1][u'value'][u'begin']
+    assert parser.parse(begin).time() == two_pm
+
+    end = result[1][u'value'][u'end']
+    assert parser.parse(end).time() == three_pm
+
+
+def test_parse_christmas(sutime_with_mark_time_ranges, input_christmas_eve):
+    result = sutime_with_mark_time_ranges.parse(input_christmas_eve)
+
+    assert len(result) == 1
+
+    assert result[0][u'type'] == u'SET'
+    assert result[0][u'value'] == u'XXXX-12-24'
+
+
+def test_sunday_night(sutime_with_mark_time_ranges, input_sunday_night):
+    result = sutime_with_mark_time_ranges.parse(input_sunday_night)
+    assert len(result) == 1

--- a/test.sh
+++ b/test.sh
@@ -3,3 +3,4 @@
 # We have to run tests separately as the JVM can only be started once per test
 pytest sutime/test/test_sutime.py
 pytest sutime/test/test_sutime_time_ranges.py
+pytest sutime/test/test_sutime_jvm_flags.py

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,5 @@
+#! /bin/bash -x
+
+# We have to run tests separately as the JVM can only be started once per test
+pytest sutime/test/test_sutime.py
+pytest sutime/test/test_sutime_time_ranges.py


### PR DESCRIPTION
The goal of this pull request is to support JVM flags when SUTime starts up the JVM, which allows users to specify the heap size and set other relevant flags. This is a fully backwards-compatible change that adds an additional keyword argument to the SUTime initializer. Without this change, for the user to start with JVM with their own flags, they would need to specify the correct classpath which is currently done with internal methods within SUTime they would need to replicate.

When adding the `jvm_flags` argument, I also addressed a bug that the `jar` argument has a mutable default value, meaning all instances using the default value will share it if someone appends to the `.jars` attribute of a single instance.

In order to add a test for the JVM flags, I had to make a large number of changes to the way that the tests are set up, which is by lines the vast majority of this PR. First, CircleCI had deprecated the use of `circle.yml` and now requires `.circleci/config.yml`. Second, the tests needed to be split into separate files for each invocation of the JVM, as attempting to instantiate multiple `SUTime` objects that each start the JVM will fail with an `OSError` from JPype. (It's not clear to me how the old tests ever passed after the `sutime_with_mark_time_ranges` fixture was added; perhaps newer versions of JPype are stricter about starting the JVM multiple times? Also, the JVM cannot be successfully shut down within a process, see https://jpype.readthedocs.io/en/latest/userguide.html#unloading-the-jvm , so we can't clean up after SUTime instantiation.)

So this is a big PR for a small change, but almost all of it is related to updating the tests. I'm happy to make any changes you'd like.